### PR TITLE
add function to TL_Pysces to write EnzymeML document with fit results

### DIFF
--- a/pyenzyme/thinlayers/TL_Pysces.py
+++ b/pyenzyme/thinlayers/TL_Pysces.py
@@ -113,7 +113,7 @@ class ThinLayerPysces():
         self.fit = self.mini.minimize()
         return self.fit
 
-    def writeEnzymeML(self, name=None, path=None):
+    def writeEnzymeML(self, name=None, path='.'):
         '''
         Write EnzymeML document with fit results.
         WARNING: will overwrite old EnzymeML document if no new name is provided.
@@ -125,11 +125,7 @@ class ThinLayerPysces():
         if name:
             self.enzmldoc.setName(name)
         self._addResultsToEnzymeML()
-        if path:
-            self.enzmldoc.toFile(path)
-        else:
-            self.enzmldoc.toFile('.')
-        
+        self.enzmldoc.toFile(path)
 
     def _addResultsToEnzymeML(self):
         '''

--- a/pyenzyme/thinlayers/TL_Pysces.py
+++ b/pyenzyme/thinlayers/TL_Pysces.py
@@ -110,4 +110,29 @@ class ThinLayerPysces():
         if params is None:
             params = self._makeLmfitParameters()
         self.mini = lmfit.Minimizer(self._residual, params)
-        return self.mini.minimize()
+        self.fit = self.mini.minimize()
+        return self.fit
+
+    def _addResultsToEnzymeML(self):
+        '''
+        Add fit results to EnzymeML document.
+        '''
+        for name, value in self.fit.params.valuesdict().items():
+            reaction_id = name.split('_')[0]
+            parameter_name = "_".join(name.split('_')[1:])
+            parameters = self.enzmldoc.getReaction(reaction_id).getModel().getParameters()
+            (value_old, unit) = parameters[parameter_name]
+            parameters[parameter_name] = (value, unit)
+
+    def writeEnzymeML(self, name=None):
+        '''
+        Write EnzymeML document with fit results.
+        WARNING: will overwrite old EnzymeML document if no new name is provided.
+
+        Args:
+            name (str): new name for EnzymeML document
+        '''
+        if name is not None:
+            self.enzmldoc.setName(name)
+        self._addResultsToEnzymeML()
+        self.enzmldoc.toFile('.')

--- a/pyenzyme/thinlayers/TL_Pysces.py
+++ b/pyenzyme/thinlayers/TL_Pysces.py
@@ -113,6 +113,24 @@ class ThinLayerPysces():
         self.fit = self.mini.minimize()
         return self.fit
 
+    def writeEnzymeML(self, name=None, path=None):
+        '''
+        Write EnzymeML document with fit results.
+        WARNING: will overwrite old EnzymeML document if no new name is provided.
+
+        Args:
+            name (str): new name for EnzymeML document
+            path (str): EnzymeML document is written to this destination 
+        '''
+        if name:
+            self.enzmldoc.setName(name)
+        self._addResultsToEnzymeML()
+        if path:
+            self.enzmldoc.toFile(path)
+        else:
+            self.enzmldoc.toFile('.')
+        
+
     def _addResultsToEnzymeML(self):
         '''
         Add fit results to EnzymeML document.
@@ -124,15 +142,3 @@ class ThinLayerPysces():
             (value_old, unit) = parameters[parameter_name]
             parameters[parameter_name] = (value, unit)
 
-    def writeEnzymeML(self, name=None):
-        '''
-        Write EnzymeML document with fit results.
-        WARNING: will overwrite old EnzymeML document if no new name is provided.
-
-        Args:
-            name (str): new name for EnzymeML document
-        '''
-        if name is not None:
-            self.enzmldoc.setName(name)
-        self._addResultsToEnzymeML()
-        self.enzmldoc.toFile('.')


### PR DESCRIPTION
# Changes
Add function to automatically add fit results to the EnzymeML document and write it.
Example code:
```
psc = ThinLayerPysces('PGM-ENO.omex')  
fit = psc.runOptimisation()  
psc.writeEnzymeML('PGM-ENO_results')
```
This will change the name of the EnzymeML document to PGM-ENO_results and create the new document.
If no name is given, the old EnzymeML document will be overwritten.
# Motivation
closes #15

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/enzymeml/pyenzyme/16)
<!-- Reviewable:end -->
