### PR TITLE
Fix residual computation

### DIFF
--- a/pyenzyme/thinlayers/TL_Pysces.py
+++ b/pyenzyme/thinlayers/TL_Pysces.py
@@ -89,8 +89,12 @@ class ThinLayerPysces():
 
     def _residual(self, params):
         exp_data, inits = self._getExperimentalData()
+        # get columns of experimental data, corresponding to measured reactants
+        cols = list(exp_data.columns) 
         model_data = self._simulateExpData(params)
-        return np.array(exp_data - model_data)
+        # create dataframe containing only modelled data for reactants that have also been measured
+        new_model_data = model_data.drop(model_data.columns.difference(cols), axis=1)
+        return np.array(exp_data - new_model_data)
 
     def _getParamsFromEnzymeML(self):
         params = {}


### PR DESCRIPTION
## Changes
Refactor residual function to subtract only reactants that have been measured.
Now the dataframe with the modelled time-course data will only contain columns/data for reactants that also have been measured.

## Motivation
closes #17 
Previously the residual tried to subtract modelled time-course values of reactants that have no time-course measurements.
This resulted in an error for the minimization step, since the dataframe contained NaN values.

## Tested
This was tested with a dataset of Maria Pinto, with the reaction:
L-cysteine -> sulfide + L-alanine
Measured was the time-course of L-cysteine and sulfide but not L-alanine.
The experimental data contained the columns s0 and s1 (L-cysteine and sulfide)
The modelled data previously contained s0, s1 and s2
Now it also contains only s0 and s1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/enzymeml/pyenzyme/18)
<!-- Reviewable:end -->
