### PR TITLE
Support simulation of EnzymeML Documents

### DIFF
--- a/pyenzyme/enzymeml/core/enzymemldocument.py
+++ b/pyenzyme/enzymeml/core/enzymemldocument.py
@@ -855,6 +855,31 @@ class EnzymeMLDocument(EnzymeMLBase):
                 init_values, file_handle, default_flow_style=False, sort_keys=False
             )
 
+    def generateSimulationTemplate(self, path: str):
+        """Generates an Initial Value template that can be used by a simulation method"""
+
+        class MyDumper(yaml.Dumper):
+            # Helper Class for pretty writing yaml
+            def increase_indent(self, flow=False, indentless=False):
+                return super(MyDumper, self).increase_indent(flow, False)
+
+        # Gather all species
+        all_species = {**self.reactant_dict, **self.protein_dict, **self.complex_dict}
+
+        init_dict = {
+            species.id: {"name": species.name, "init_conc": species.init_conc}
+            for species in all_species.values()
+        }
+
+        path = os.path.join(path, "initial_concentrations.yaml")
+
+        with open(path, "w") as file:
+            yaml_string = yaml.dump(
+                init_dict, Dumper=MyDumper, default_flow_style=False, sort_keys=False
+            )
+
+            file.write(yaml_string)
+
     def applyModelInitialization(self, path: str, to_values: bool = False) -> None:
         """Adds initial values per reaction to the model from a YAML config file.
 


### PR DESCRIPTION
Since we already support optimization using our Thin Layers, it would be great to extend these towards simulation. In addition, both COPASI and PySCeS are used for simulation, thus it just feels natural to add this functionality.

Tasks to be done:

- [x] Extend PySCeS Thin Layer
- [ ] Extend COPASI Thin Layer
- [ ] Add tests to validate functionality

With the opening of this PR the PySCeS implementation has already been done. I am currently working out a test from simulating an `EnzymeMLDocument` and using the `optimize`-method to validate that the correct parameters are estimated.