### PR TITLE
PyYAML causing pip error fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
         "numexpr",
         "seaborn",
         "plotly",
-        "pyyaml==5.4.1",
+        "pyyaml",
         "deprecation",
         "xmltodict",
         "requests"


### PR DESCRIPTION
Currently PyEnzyme cannot be installed due to the hard-coded version of `pyyaml`. The version dependency has been removed within this PR to re-establish working installations.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/EnzymeML/PyEnzyme/60)
<!-- Reviewable:end -->
