### PR TITLE
 - fix reading to be compatible with newer versions of libsbml

### DIFF
--- a/pyenzyme/enzymeml/tools/enzymemlreader.py
+++ b/pyenzyme/enzymeml/tools/enzymemlreader.py
@@ -183,7 +183,7 @@ class EnzymeMLReader:
     @staticmethod
     def _sboterm_to_enum(sbo_term: int) -> Optional[SBOTerm]:
         try:
-            sbo_string: str = libsbml.SBO_intToString(sbo_term)
+            sbo_string: str = libsbml.SBO.intToString(sbo_term)
 
             if len(sbo_string) == 0:
                 return None
@@ -568,7 +568,7 @@ class EnzymeMLReader:
             species_id = species_ref.getSpecies()
             stoichiometry = 1.0 if modifiers else species_ref.getStoichiometry()
             constant = True if modifiers else species_ref.getConstant()
-            sbo_term = libsbml.SBO_intToString(species_ref.getSBOTerm())
+            sbo_term = libsbml.SBO.intToString(species_ref.getSBOTerm())
 
             if sbo_term:
                 ontology = SBOTerm(sbo_term)


### PR DESCRIPTION
Newer versions of libSBML (generated with SWIG 4) no longer contain the underscore. So this fix is needed to ensure that files can still be read. (SWIG 3 would have generated the `SBO.` methods as well, so they are still compatible with older versions).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/EnzymeML/PyEnzyme/61)
<!-- Reviewable:end -->
