### PR TITLE
#62 : use write.close rather than writer.save

### DIFF
--- a/pyenzyme/enzymeml/tools/validator.py
+++ b/pyenzyme/enzymeml/tools/validator.py
@@ -381,7 +381,7 @@ class EnzymeMLValidator:
             # Write to row
             writer.sheets["validation"].set_row(row_idx + 1, 25, style)
 
-        writer.save()
+        writer.close()
 
     # ! Template conversion
     @classmethod


### PR DESCRIPTION
Since `save` is not part of the public API it has been removed.

fixes #62

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/EnzymeML/PyEnzyme/63)
<!-- Reviewable:end -->
