### PR TITLE
Fix 313 enum variants

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ['3.10', '3.11', '3.12', '3.13']
 
     steps:
       - name: Checkout

--- a/pyenzyme/sbml/serializer.py
+++ b/pyenzyme/sbml/serializer.py
@@ -468,7 +468,6 @@ def _validate_sbml(sbmldoc: libsbml.SBMLDocument) -> None:
     """Validate the SBML document using the libSBML function."""
 
     sbml_errors = sbmldoc.checkConsistency()
-    valid = True
 
     if sbml_errors and not print_warnings:
         logger.warning(
@@ -479,7 +478,6 @@ def _validate_sbml(sbmldoc: libsbml.SBMLDocument) -> None:
         severity = sbmldoc.getError(error).getSeverity()
 
         if severity == libsbml.LIBSBML_SEV_ERROR:
-            valid = False
             logger.error(
                 sbmldoc.getError(error).getMessage().strip().replace("\n", " ")
             )

--- a/pyenzyme/units/units.py
+++ b/pyenzyme/units/units.py
@@ -1,5 +1,5 @@
 from copy import deepcopy
-from enum import Enum
+from enum import Enum, member
 from functools import partial
 
 from pydantic import model_validator
@@ -49,10 +49,10 @@ def set_scale(unit: _BaseUnit, scale: int) -> _BaseUnit:
 class Prefix(Enum):
     """Enumeration for unit prefixes with corresponding scales."""
 
-    k = partial(set_scale, scale=3.0)
-    m = partial(set_scale, scale=-3.0)
-    u = partial(set_scale, scale=-6.0)
-    n = partial(set_scale, scale=-9.0)
+    k = member(partial(set_scale, scale=3))
+    m = member(partial(set_scale, scale=-3))
+    u = member(partial(set_scale, scale=-6))
+    n = member(partial(set_scale, scale=-9))
 
     def __mul__(self, other: _BaseUnit) -> _BaseUnit:
         """Multiply prefix with a BaseUnit.
@@ -68,6 +68,7 @@ class Prefix(Enum):
         Raises:
             TypeError: If the other operand is not a BaseUnit.
         """
+        print(self.value)
         if isinstance(other, _BaseUnit):
             return self.value(other)
 

--- a/pyenzyme/units/units.py
+++ b/pyenzyme/units/units.py
@@ -1,6 +1,7 @@
 from copy import deepcopy
-from enum import Enum, member
+from enum import Enum
 from functools import partial
+import sys
 
 from pydantic import model_validator
 
@@ -49,10 +50,18 @@ def set_scale(unit: _BaseUnit, scale: int) -> _BaseUnit:
 class Prefix(Enum):
     """Enumeration for unit prefixes with corresponding scales."""
 
-    k = member(partial(set_scale, scale=3))
-    m = member(partial(set_scale, scale=-3))
-    u = member(partial(set_scale, scale=-6))
-    n = member(partial(set_scale, scale=-9))
+    if sys.version_info >= (3, 13):
+        from enum import member
+
+        k = member(partial(set_scale, scale=3))
+        m = member(partial(set_scale, scale=-3))
+        u = member(partial(set_scale, scale=-6))
+        n = member(partial(set_scale, scale=-9))
+    else:
+        k = partial(set_scale, scale=3)
+        m = partial(set_scale, scale=-3)
+        u = partial(set_scale, scale=-6)
+        n = partial(set_scale, scale=-9)
 
     def __mul__(self, other: _BaseUnit) -> _BaseUnit:
         """Multiply prefix with a BaseUnit.


### PR DESCRIPTION
As highlighted in #72 the enumeration variants for units need to explicitly implement `enum.members` to allow the usage of `partial` in a non-context environment. Tests have been extended to Python `3.13` to check possible other future incompatibilites.

@jmrohwer can you please test it to verify it is working on your machine too?

* Closes #72

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/EnzymeML/PyEnzyme/73)
<!-- Reviewable:end -->
