### PR TITLE
Add missing `.gitmodules`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "specs"]
+	path = specs
+	url = https://github.com/EnzymeML/enzymeml-specifications.git


### PR DESCRIPTION
Issue #77 and #74 have hinted to problems of submodule resolution. Due to local `.gitignore` specifications, which exclude all hidden files/dirs the important `.gitmodules` has not been pushed.

This pull request adds a new Git submodule to the repository. The submodule points to the `EnzymeML/enzymeml-specifications` repository and is configured under the path `specs`.

* [`.gitmodules`](diffhunk://#diff-fe7afb5c9c916e521401d3fcfb4277d5071798c3baf83baf11d6071742823584R1-R3): Added a submodule named `specs` with the URL `https://github.com/EnzymeML/enzymeml-specifications.git`.

- Closes #77 
- Closes #74

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/EnzymeML/PyEnzyme/78)
<!-- Reviewable:end -->
