### PR TITLE
Sort by measurement group feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">
   PyEnzyme<br>
-  <img src="https://img.shields.io/badge/PyEnzyme-1.1.5-blue" alt="v2.0.0">
+  <img alt="PyPI - Version" src="https://img.shields.io/pypi/v/pyenzyme">
   <img src="https://github.com/EnzymeML/PyEnzyme/actions/workflows/unit-tests.yaml/badge.svg" alt="Build Badge"> 
 </a>
 <a href="https://www.codacy.com/gh/EnzymeML/PyEnzyme/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=EnzymeML/PyEnzyme&amp;utm_campaign=Badge_Grade"><img src="https://app.codacy.com/project/badge/Grade/4ceb8d010e7b456c926c8b18737ff102"/></a>

--- a/pyenzyme/__init__.py
+++ b/pyenzyme/__init__.py
@@ -45,4 +45,4 @@ __all__ = [
     "group_measurements",
 ]
 
-__version__ = "2.0.0"
+__version__ = "2.1.0"

--- a/pyenzyme/__init__.py
+++ b/pyenzyme/__init__.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 
 from mdmodels.units.unit_definition import UnitDefinition, UnitType
 
-from .versions.v2 import *  # noqa: F403
-from .versions.io import EnzymeMLHandler
-from .fetcher import *  # noqa: F403
 from .composer import compose
-from .suite import EnzymeMLSuite
+from .fetcher import *  # noqa: F403
 from .plotting import plot, plot_interactive
 from .pretty import summary
+from .suite import EnzymeMLSuite
+from .tools import group_measurements
+from .versions.io import EnzymeMLHandler
+from .versions.v2 import *  # noqa: F403
 
 # Input functions
 from_csv = EnzymeMLHandler.from_csv
@@ -41,6 +42,7 @@ __all__ = [
     "plot",
     "plot_interactive",
     "summary",
+    "group_measurements",
 ]
 
 __version__ = "2.0.0"

--- a/pyenzyme/petab/io.py
+++ b/pyenzyme/petab/io.py
@@ -7,11 +7,11 @@ import yaml
 from pyenzyme.sbml.serializer import to_sbml
 from pyenzyme.versions import v2
 
-from .petab import PEtab, Problem
 from .conditions import ConditionRow
-from .observables import ObservableRow
 from .measurements import MeasurementRow
+from .observables import ObservableRow
 from .parameters import ParameterRow
+from .petab import PEtab, Problem
 
 # Default filenames for PEtab format components
 PARAMETER_FILENAME = "parameters.tsv"

--- a/pyenzyme/sbml/serializer.py
+++ b/pyenzyme/sbml/serializer.py
@@ -10,15 +10,13 @@ from loguru import logger
 
 import pyenzyme as pe
 import pyenzyme.tools as tools
-
-from pyenzyme import rdf
+from pyenzyme import UnitDefinition, rdf
 from pyenzyme import xmlutils as _xml
 from pyenzyme.logging import add_logger
 from pyenzyme.sbml import create_sbml_omex
 from pyenzyme.sbml.validation import validate_sbml_export
 from pyenzyme.sbml.versions import v2
 from pyenzyme.tabular import to_pandas
-from pyenzyme import UnitDefinition
 
 NSMAP = {"enzymeml": "https://www.enzymeml.org/v2"}
 CELSIUS_CONVERSION_FACTOR = 273.15

--- a/pyenzyme/sbml/validation.py
+++ b/pyenzyme/sbml/validation.py
@@ -1,10 +1,17 @@
 from loguru import logger
 
-import pyenzyme as pe
 import pyenzyme.tools as tools
+from pyenzyme.versions.v2 import (
+    EnzymeMLDocument,
+    EquationType,
+    MeasurementData,
+    Parameter,
+    ReactionElement,
+    UnitDefinitionAnnot,
+)
 
 
-def validate_sbml_export(doc: pe.EnzymeMLDocument) -> bool:
+def validate_sbml_export(doc: EnzymeMLDocument) -> bool:
     """This function validates the SBML export of an EnzymeML document.
 
     Args:
@@ -26,7 +33,7 @@ def validate_sbml_export(doc: pe.EnzymeMLDocument) -> bool:
     return result
 
 
-def _check_consistent_vessel_ids(doc: pe.EnzymeMLDocument) -> bool:
+def _check_consistent_vessel_ids(doc: EnzymeMLDocument) -> bool:
     """This validator checks whether all species have a vessel id that exists in the document.
 
     SBML documents require that all species have a vessel id that exists in the document and
@@ -62,7 +69,7 @@ def _check_consistent_vessel_ids(doc: pe.EnzymeMLDocument) -> bool:
     return all(result)
 
 
-def _check_equation_either_rule_or_reaction(doc: pe.EnzymeMLDocument) -> bool:
+def _check_equation_either_rule_or_reaction(doc: EnzymeMLDocument) -> bool:
     """This validator checks whether there are either rules or reactions in the document.
 
     SBML documents require that there are either rules or reactions in the document. For instance,
@@ -78,10 +85,10 @@ def _check_equation_either_rule_or_reaction(doc: pe.EnzymeMLDocument) -> bool:
     """
 
     species_w_rate = {
-        eq.species_id for eq in doc.equations if eq.equation_type == pe.EquationType.ODE
+        eq.species_id for eq in doc.equations if eq.equation_type == EquationType.ODE
     }
 
-    all_reaction_elements = tools.extract(obj=doc, target=pe.ReactionElement)
+    all_reaction_elements = tools.extract(obj=doc, target=ReactionElement)
     result, validated = [], set()
 
     for element in all_reaction_elements:
@@ -98,7 +105,7 @@ def _check_equation_either_rule_or_reaction(doc: pe.EnzymeMLDocument) -> bool:
     return all(result)
 
 
-def _check_units_exist(doc: pe.EnzymeMLDocument) -> bool:
+def _check_units_exist(doc: EnzymeMLDocument) -> bool:
     """This validator checks whether all units in the document are defined in the SBML standard.
 
     Args:
@@ -109,17 +116,17 @@ def _check_units_exist(doc: pe.EnzymeMLDocument) -> bool:
     """
 
     mandatory_unit_objects = [
-        *tools.extract(obj=doc, target=pe.MeasurementData),
+        *tools.extract(obj=doc, target=MeasurementData),
     ]
 
     optional_unit_objects = [
-        *tools.extract(obj=doc, target=pe.Parameter),
+        *tools.extract(obj=doc, target=Parameter),
     ]
 
     result = []
 
     for unit_obj in mandatory_unit_objects:
-        units = tools.extract(obj=unit_obj, target=pe.UnitDefinition)
+        units = tools.extract(obj=unit_obj, target=UnitDefinitionAnnot)
 
         if len(units) == 0:
             logger.error(
@@ -128,7 +135,7 @@ def _check_units_exist(doc: pe.EnzymeMLDocument) -> bool:
             result.append(False)
 
     for unit_obj in optional_unit_objects:
-        units = tools.extract(obj=unit_obj, target=pe.UnitDefinition)
+        units = tools.extract(obj=unit_obj, target=UnitDefinitionAnnot)
 
         if len(units) == 0:
             logger.warning(
@@ -140,7 +147,7 @@ def _check_units_exist(doc: pe.EnzymeMLDocument) -> bool:
     return all(result)
 
 
-def _check_assigned_params_are_not_constant(doc: pe.EnzymeMLDocument) -> bool:
+def _check_assigned_params_are_not_constant(doc: EnzymeMLDocument) -> bool:
     """This validator checks whether all assigned parameters are not constant.
 
     If a parameter is assigned a value through an assignment rule, it should not be constant.
@@ -154,7 +161,7 @@ def _check_assigned_params_are_not_constant(doc: pe.EnzymeMLDocument) -> bool:
         bool: True if all assigned parameters are valid, False otherwise.
     """
 
-    assignments = doc.filter_equations(equation_type=pe.EquationType.ASSIGNMENT)
+    assignments = doc.filter_equations(equation_type=EquationType.ASSIGNMENT)
     result = []
 
     for assignment in assignments:

--- a/pyenzyme/sbml/validation.py
+++ b/pyenzyme/sbml/validation.py
@@ -118,7 +118,6 @@ def _check_units_exist(doc: EnzymeMLDocument) -> bool:
     mandatory_unit_objects = [
         *tools.extract(obj=doc, target=MeasurementData),
     ]
-    print(f"Found {len(mandatory_unit_objects)} mandatory unit objects.")
 
     optional_unit_objects = [
         *tools.extract(obj=doc, target=Parameter),

--- a/pyenzyme/sbml/validation.py
+++ b/pyenzyme/sbml/validation.py
@@ -1,4 +1,5 @@
 from loguru import logger
+from mdmodels.units.unit_definition import UnitDefinition
 
 import pyenzyme.tools as tools
 from pyenzyme.versions.v2 import (
@@ -7,7 +8,6 @@ from pyenzyme.versions.v2 import (
     MeasurementData,
     Parameter,
     ReactionElement,
-    UnitDefinitionAnnot,
 )
 
 
@@ -118,6 +118,7 @@ def _check_units_exist(doc: EnzymeMLDocument) -> bool:
     mandatory_unit_objects = [
         *tools.extract(obj=doc, target=MeasurementData),
     ]
+    print(f"Found {len(mandatory_unit_objects)} mandatory unit objects.")
 
     optional_unit_objects = [
         *tools.extract(obj=doc, target=Parameter),
@@ -126,16 +127,16 @@ def _check_units_exist(doc: EnzymeMLDocument) -> bool:
     result = []
 
     for unit_obj in mandatory_unit_objects:
-        units = tools.extract(obj=unit_obj, target=UnitDefinitionAnnot)
+        units = tools.extract(obj=unit_obj, target=UnitDefinition)
 
         if len(units) == 0:
             logger.error(
-                f"Object of type '{type(unit_obj).__name__}' with id '{unit_obj.id}' does not have a unit defined."
+                f"Object of type '{type(unit_obj).__name__}' with id '{unit_obj.species_id}' does not have a unit defined."
             )
             result.append(False)
 
     for unit_obj in optional_unit_objects:
-        units = tools.extract(obj=unit_obj, target=UnitDefinitionAnnot)
+        units = tools.extract(obj=unit_obj, target=UnitDefinition)
 
         if len(units) == 0:
             logger.warning(

--- a/pyenzyme/sbml/versions/v1.py
+++ b/pyenzyme/sbml/versions/v1.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 import pandas as pd
+from mdmodels.units.unit_definition import UnitDefinition
 from pydantic import computed_field
 from pydantic_xml import BaseXmlModel, attr, element, wrapped
 
 from pyenzyme.sbml.utils import _get_unit
 from pyenzyme.sbml.versions.v2 import VariableAnnot
-from pyenzyme.versions.v2 import DataTypes, Measurement, UnitDefinitionAnnot
+from pyenzyme.versions.v2 import DataTypes, Measurement
 
 
 class V1Annotation(
@@ -199,7 +200,7 @@ class DataAnnot(
     def to_measurements(
         self,
         meas_data: dict[str, pd.DataFrame],
-        units: dict[str, UnitDefinitionAnnot],
+        units: dict[str, UnitDefinition],
     ) -> list[Measurement]:
         """
         Converts the data annotation to version 2 format.
@@ -209,7 +210,7 @@ class DataAnnot(
 
         Args:
             meas_data (dict[str, pd.DataFrame]): A dictionary of dataframes.
-            units (dict[str, UnitDefinitionAnnot]): A dictionary of unit definitions.
+            units (dict[str, UnitDefinition]): A dictionary of unit definitions.
 
         Returns:
             list[Measurement]: A list of measurements.
@@ -256,7 +257,7 @@ class DataAnnot(
         df: pd.DataFrame,
         file_format: FormatAnnot,
         measurement: Measurement,
-        units: dict[str, UnitDefinitionAnnot],
+        units: dict[str, UnitDefinition],
     ) -> None:
         """
         Maps columns from the dataframe to the measurement.
@@ -269,7 +270,7 @@ class DataAnnot(
             df (pd.DataFrame): The dataframe containing the data.
             file_format (FormatAnnot): The format annotation.
             measurement (Measurement): The measurement to map the columns to.
-            units (dict[str, UnitDefinitionAnnot]): A dictionary of unit definitions.
+            units (dict[str, UnitDefinition]): A dictionary of unit definitions.
         """
 
         for col in file_format.columns:
@@ -294,7 +295,7 @@ class DataAnnot(
     def _map_species_values(
         col: ColumnAnnot,
         measurement: Measurement,
-        unit: UnitDefinitionAnnot,
+        unit: UnitDefinition,
         values: list[float],
     ):
         """
@@ -306,7 +307,7 @@ class DataAnnot(
         Args:
             col (ColumnAnnot): The column annotation.
             measurement (Measurement): The measurement to map the values to.
-            unit (UnitDefinitionAnnot): The unit definition.
+            unit (UnitDefinition): The unit definition.
             values (list[float]): The list of values.
         """
         species_data = measurement.filter_species_data(species_id=col.species_id)
@@ -331,7 +332,7 @@ class DataAnnot(
 
         Args:
             measurement (Measurement): The measurement to map the values to.
-            unit (UnitDefinitionAnnot): The unit definition.
+            unit (UnitDefinition): The unit definition.
             values (list[float]): The list of time values.
         """
         # Map time to all species data

--- a/pyenzyme/sbml/versions/v1.py
+++ b/pyenzyme/sbml/versions/v1.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 import pandas as pd
 from pydantic import computed_field
-from pydantic_xml import element, BaseXmlModel, attr, wrapped
+from pydantic_xml import BaseXmlModel, attr, element, wrapped
 
-from pyenzyme import Measurement, UnitDefinition, DataTypes
 from pyenzyme.sbml.utils import _get_unit
 from pyenzyme.sbml.versions.v2 import VariableAnnot
+from pyenzyme.versions.v2 import DataTypes, Measurement, UnitDefinitionAnnot
 
 
 class V1Annotation(
@@ -199,7 +199,7 @@ class DataAnnot(
     def to_measurements(
         self,
         meas_data: dict[str, pd.DataFrame],
-        units: dict[str, UnitDefinition],
+        units: dict[str, UnitDefinitionAnnot],
     ) -> list[Measurement]:
         """
         Converts the data annotation to version 2 format.
@@ -209,7 +209,7 @@ class DataAnnot(
 
         Args:
             meas_data (dict[str, pd.DataFrame]): A dictionary of dataframes.
-            units (dict[str, UnitDefinition]): A dictionary of unit definitions.
+            units (dict[str, UnitDefinitionAnnot]): A dictionary of unit definitions.
 
         Returns:
             list[Measurement]: A list of measurements.
@@ -256,7 +256,7 @@ class DataAnnot(
         df: pd.DataFrame,
         file_format: FormatAnnot,
         measurement: Measurement,
-        units: dict[str, UnitDefinition],
+        units: dict[str, UnitDefinitionAnnot],
     ) -> None:
         """
         Maps columns from the dataframe to the measurement.
@@ -269,7 +269,7 @@ class DataAnnot(
             df (pd.DataFrame): The dataframe containing the data.
             file_format (FormatAnnot): The format annotation.
             measurement (Measurement): The measurement to map the columns to.
-            units (dict[str, UnitDefinition]): A dictionary of unit definitions.
+            units (dict[str, UnitDefinitionAnnot]): A dictionary of unit definitions.
         """
 
         for col in file_format.columns:
@@ -294,7 +294,7 @@ class DataAnnot(
     def _map_species_values(
         col: ColumnAnnot,
         measurement: Measurement,
-        unit: UnitDefinition,
+        unit: UnitDefinitionAnnot,
         values: list[float],
     ):
         """
@@ -306,7 +306,7 @@ class DataAnnot(
         Args:
             col (ColumnAnnot): The column annotation.
             measurement (Measurement): The measurement to map the values to.
-            unit (UnitDefinition): The unit definition.
+            unit (UnitDefinitionAnnot): The unit definition.
             values (list[float]): The list of values.
         """
         species_data = measurement.filter_species_data(species_id=col.species_id)
@@ -331,7 +331,7 @@ class DataAnnot(
 
         Args:
             measurement (Measurement): The measurement to map the values to.
-            unit (UnitDefinition): The unit definition.
+            unit (UnitDefinitionAnnot): The unit definition.
             values (list[float]): The list of time values.
         """
         # Map time to all species data

--- a/pyenzyme/sbml/versions/v2.py
+++ b/pyenzyme/sbml/versions/v2.py
@@ -13,11 +13,12 @@ small molecules, proteins, complexes, experimental measurements, and parameters.
 from __future__ import annotations
 
 import pandas as pd
+from mdmodels.units.unit_definition import UnitDefinition
 from pydantic import field_validator
 from pydantic_xml import BaseXmlModel, attr, element
 
 from pyenzyme.sbml.utils import _get_unit
-from pyenzyme.versions.v2 import DataTypes, Measurement, UnitDefinitionAnnot
+from pyenzyme.versions.v2 import DataTypes, Measurement
 
 
 class BaseAnnot(BaseXmlModel):
@@ -215,7 +216,7 @@ class DataAnnot(
     def to_measurements(
         self,
         meas_data: dict[str, pd.DataFrame],
-        units: dict[str, UnitDefinitionAnnot],
+        units: dict[str, UnitDefinition],
     ) -> list[Measurement]:
         """
         Converts data annotations to Measurement objects.
@@ -225,7 +226,7 @@ class DataAnnot(
 
         Args:
             meas_data (dict[str, pd.DataFrame]): Dictionary mapping file paths to data frames.
-            units (dict[str, UnitDefinitionAnnot]): Dictionary mapping unit IDs to UnitDefinitionAnnot objects.
+            units (dict[str, UnitDefinition]): Dictionary mapping unit IDs to UnitDefinition objects.
 
         Returns:
             list[Measurement]: List of created Measurement objects.
@@ -286,7 +287,7 @@ class MeasurementAnnot(
     def to_measurement(
         self,
         meas_data: pd.DataFrame,
-        units: dict[str, UnitDefinitionAnnot],
+        units: dict[str, UnitDefinition],
     ):
         """
         Converts a measurement annotation to a Measurement object.
@@ -296,7 +297,7 @@ class MeasurementAnnot(
 
         Args:
             meas_data (pd.DataFrame): The data frame containing measurement data.
-            units (dict[str, UnitDefinitionAnnot]): Dictionary mapping unit IDs to UnitDefinitionAnnot objects.
+            units (dict[str, UnitDefinition]): Dictionary mapping unit IDs to UnitDefinition objects.
 
         Returns:
             Measurement: The created Measurement object.
@@ -349,7 +350,7 @@ class MeasurementAnnot(
         df_sub: pd.DataFrame,
         measurement: Measurement,
         species: SpeciesDataAnnot,
-        units: dict[str, UnitDefinitionAnnot],
+        units: dict[str, UnitDefinition],
     ):
         """
         Maps species data from a data frame to a Measurement object.
@@ -361,7 +362,7 @@ class MeasurementAnnot(
             df_sub (pd.DataFrame): The filtered data frame for the current measurement.
             measurement (Measurement): The Measurement object to add data to.
             species (SpeciesDataAnnot): The species data annotation.
-            units (dict[str, UnitDefinitionAnnot]): Dictionary mapping unit IDs to UnitDefinitionAnnot objects.
+            units (dict[str, UnitDefinition]): Dictionary mapping unit IDs to UnitDefinition objects.
         """
         if species.species_id in df_sub.columns:
             data = df_sub[species.species_id].to_list()

--- a/pyenzyme/sbml/versions/v2.py
+++ b/pyenzyme/sbml/versions/v2.py
@@ -14,10 +14,10 @@ from __future__ import annotations
 
 import pandas as pd
 from pydantic import field_validator
-from pydantic_xml import element, attr, BaseXmlModel
+from pydantic_xml import BaseXmlModel, attr, element
 
-from pyenzyme import DataTypes, Measurement, UnitDefinition
 from pyenzyme.sbml.utils import _get_unit
+from pyenzyme.versions.v2 import DataTypes, Measurement, UnitDefinitionAnnot
 
 
 class BaseAnnot(BaseXmlModel):
@@ -215,7 +215,7 @@ class DataAnnot(
     def to_measurements(
         self,
         meas_data: dict[str, pd.DataFrame],
-        units: dict[str, UnitDefinition],
+        units: dict[str, UnitDefinitionAnnot],
     ) -> list[Measurement]:
         """
         Converts data annotations to Measurement objects.
@@ -225,7 +225,7 @@ class DataAnnot(
 
         Args:
             meas_data (dict[str, pd.DataFrame]): Dictionary mapping file paths to data frames.
-            units (dict[str, UnitDefinition]): Dictionary mapping unit IDs to UnitDefinition objects.
+            units (dict[str, UnitDefinitionAnnot]): Dictionary mapping unit IDs to UnitDefinitionAnnot objects.
 
         Returns:
             list[Measurement]: List of created Measurement objects.
@@ -286,7 +286,7 @@ class MeasurementAnnot(
     def to_measurement(
         self,
         meas_data: pd.DataFrame,
-        units: dict[str, UnitDefinition],
+        units: dict[str, UnitDefinitionAnnot],
     ):
         """
         Converts a measurement annotation to a Measurement object.
@@ -296,7 +296,7 @@ class MeasurementAnnot(
 
         Args:
             meas_data (pd.DataFrame): The data frame containing measurement data.
-            units (dict[str, UnitDefinition]): Dictionary mapping unit IDs to UnitDefinition objects.
+            units (dict[str, UnitDefinitionAnnot]): Dictionary mapping unit IDs to UnitDefinitionAnnot objects.
 
         Returns:
             Measurement: The created Measurement object.
@@ -349,7 +349,7 @@ class MeasurementAnnot(
         df_sub: pd.DataFrame,
         measurement: Measurement,
         species: SpeciesDataAnnot,
-        units: dict[str, UnitDefinition],
+        units: dict[str, UnitDefinitionAnnot],
     ):
         """
         Maps species data from a data frame to a Measurement object.
@@ -361,7 +361,7 @@ class MeasurementAnnot(
             df_sub (pd.DataFrame): The filtered data frame for the current measurement.
             measurement (Measurement): The Measurement object to add data to.
             species (SpeciesDataAnnot): The species data annotation.
-            units (dict[str, UnitDefinition]): Dictionary mapping unit IDs to UnitDefinition objects.
+            units (dict[str, UnitDefinitionAnnot]): Dictionary mapping unit IDs to UnitDefinitionAnnot objects.
         """
         if species.species_id in df_sub.columns:
             data = df_sub[species.species_id].to_list()

--- a/pyenzyme/suite.py
+++ b/pyenzyme/suite.py
@@ -3,7 +3,8 @@ import json
 import httpx
 import rich
 
-import pyenzyme as pe
+from pyenzyme.versions.io import EnzymeMLHandler
+from pyenzyme.versions.v2 import EnzymeMLDocument
 
 
 class EnzymeMLSuite:
@@ -20,7 +21,7 @@ class EnzymeMLSuite:
         """
         self.client = httpx.Client(base_url=url)
 
-    def get_current(self) -> pe.EnzymeMLDocument:
+    def get_current(self) -> EnzymeMLDocument:
         """
         Retrieves the current EnzymeML document from the service.
 
@@ -42,9 +43,9 @@ class EnzymeMLSuite:
 
         content = response.json()["data"]["content"]
 
-        return pe.read_enzymeml_from_string(content)
+        return EnzymeMLHandler.read_enzymeml_from_string(content)
 
-    def update_current(self, doc: pe.EnzymeMLDocument):
+    def update_current(self, doc: EnzymeMLDocument):
         """
         Updates the current EnzymeML document on the service.
 

--- a/pyenzyme/tools.py
+++ b/pyenzyme/tools.py
@@ -5,7 +5,7 @@ from typing import Literal
 
 from pydantic import BaseModel
 
-from pyenzyme.versions.v2 import EnzymeMLDocument, Measurement, Parameter
+from pyenzyme.versions.v2 import EnzymeMLDocument, Measurement
 
 
 def to_dict_wo_json_ld(obj: BaseModel):
@@ -56,18 +56,6 @@ def _recursive_key_removal(obj: dict | list, key: str):
         obj.sort(key=lambda x: str(x))
         for entry in obj:
             _recursive_key_removal(entry, key)
-
-
-def get_all_parameters(enzmldoc: EnzymeMLDocument):
-    """Extracts all parameters from an EnzymeMLDocument.
-
-    Args:
-        enzmldoc (EnzymeMLDocument): The EnzymeMLDocument to extract parameters from.
-
-    Returns:
-        list[Parameter]: A list of all parameters in the EnzymeMLDocument.
-    """
-    return find_unique(enzmldoc, target=Parameter)
 
 
 def find_unique(obj, target):
@@ -200,7 +188,7 @@ def _get_measurement_conditions(
     attribute: Literal["initial", "prepared"] = "initial",
 ) -> dict:
     """
-    Extract measurement conditions as a dictionary, inclding pH and temperature.
+    Extract measurement conditions as a dictionary, including pH and temperature.
     Does not account for variation in units.
 
     Args:
@@ -214,15 +202,7 @@ def _get_measurement_conditions(
 
     # Add species conditions using the specified attribute
     for species_data in measurement.species_data:
-        if attribute == "initial":
-            value = species_data.initial
-        elif attribute == "prepared":
-            value = species_data.prepared
-        else:
-            raise ValueError(
-                f"Invalid attribute: {attribute}. Attribute must be 'initial' or 'prepared'."
-            )
-
+        value = getattr(species_data, attribute)
         if value is not None:
             conditions[species_data.species_id] = value
 

--- a/pyenzyme/tools.py
+++ b/pyenzyme/tools.py
@@ -1,6 +1,7 @@
 import functools as ft
 import json
 from enum import Enum
+from typing import Literal
 
 from pydantic import BaseModel
 
@@ -150,62 +151,80 @@ def extract(obj, target) -> list:
     return result
 
 
-def group_measurements(enzymemldoc: EnzymeMLDocument) -> EnzymeMLDocument:
+def group_measurements(
+    enzymemldoc: EnzymeMLDocument,
+    attribute: Literal["initial", "prepared"] = "initial",
+    tolerance: float = 0.0,
+) -> EnzymeMLDocument:
     """
     Groups measurements by their conditions and assigns for each unique set of conditions
     a `group_id` attribute.
 
     Args:
         enzymemldoc (EnzymeMLDocument): The EnzymeMLDocument to group measurements from.
+        attribute (Literal["initial", "prepared"]): Which concentration attribute to use for grouping.
+        tolerance (float): Percentage tolerance for numerical comparison (e.g., 0.05 for 5%) for matching groups.
 
     Returns:
         EnzymeMLDocument: The EnzymeMLDocument with grouped measurements.
     """
 
     # Create a mapping from conditions to group_id
-    conditions_to_group = {}
+    conditions_to_group: dict[tuple, str] = {}
     group_counter = 0
 
     for measurement in enzymemldoc.measurements:
         # Get conditions as a hashable representation
-        conditions = _get_measurement_conditions(measurement)
-        conditions_hash = _conditions_to_hashable(conditions)
+        conditions = _get_measurement_conditions(measurement, attribute)
 
-        # Assign group_id based on conditions
-        if conditions_hash not in conditions_to_group:
-            conditions_to_group[conditions_hash] = f"group_{group_counter}"
+        # Find matching group with tolerance
+        matching_group = _find_matching_group(
+            conditions, conditions_to_group, tolerance
+        )
+
+        if matching_group is None:
+            # Create new group
+            group_id = f"group_{group_counter}"
+            conditions_hash = _conditions_to_hashable(conditions)
+            conditions_to_group[conditions_hash] = group_id
             group_counter += 1
-
-        measurement.group_id = conditions_to_group[conditions_hash]
+            measurement.group_id = group_id
+        else:
+            measurement.group_id = matching_group
 
     return enzymemldoc
 
 
-def _get_measurement_conditions(measurement: Measurement) -> dict:
+def _get_measurement_conditions(
+    measurement: Measurement,
+    attribute: Literal["initial", "prepared"] = "initial",
+) -> dict:
     """
-    Extract measurement conditions as a dictionary.
-
-    Returns a hashable representation of conditions including:
-    - Species initial concentrations (key: species_id, value: prepared or initial concentration)
-    - pH and temperature values
+    Extract measurement conditions as a dictionary, inclding pH and temperature.
+    Does not account for variation in units.
 
     Args:
         measurement: The measurement to extract conditions from
+        attribute: Which concentration attribute to use ("initial" or "prepared")
 
     Returns:
-        dict: Conditions dictionary
+        dict: Conditions dictionary with species concentrations and environmental conditions
     """
     conditions = {}
 
-    # Add species conditions
+    # Add species conditions using the specified attribute
     for species_data in measurement.species_data:
-        # Use prepared value if available, otherwise initial value
-        if species_data.prepared is not None:
+        if attribute == "initial":
+            value = species_data.initial
+        elif attribute == "prepared":
             value = species_data.prepared
         else:
-            value = species_data.initial
+            raise ValueError(
+                f"Invalid attribute: {attribute}. Attribute must be 'initial' or 'prepared'."
+            )
 
-        conditions[species_data.species_id] = value
+        if value is not None:
+            conditions[species_data.species_id] = value
 
     # Add environmental conditions
     if measurement.ph is not None:
@@ -213,8 +232,103 @@ def _get_measurement_conditions(measurement: Measurement) -> dict:
     if measurement.temperature is not None:
         conditions["temperature"] = measurement.temperature
 
-    print(f"Conditions: {conditions}")
     return conditions
+
+
+def _find_matching_group(
+    conditions: dict,
+    conditions_to_group: dict,
+    tolerance: float,
+) -> str | None:
+    """
+    Find a matching group for given conditions within tolerance.
+
+    Args:
+        conditions: Current measurement conditions
+        conditions_to_group: Mapping of condition hashes to group IDs
+        tolerance: Percentage tolerance for numerical comparison
+
+    Returns:
+        str | None: Group ID if match found, None otherwise
+    """
+    # Exact matching
+    if tolerance == 0.0:
+        conditions_hash = _conditions_to_hashable(conditions)
+        return conditions_to_group.get(conditions_hash)
+
+    # Tolerance-based matching
+    for existing_conditions_hash, group_id in conditions_to_group.items():
+        existing_conditions = dict(existing_conditions_hash)
+
+        if _conditions_match_with_tolerance(conditions, existing_conditions, tolerance):
+            return group_id
+
+    return None
+
+
+def _conditions_match_with_tolerance(
+    conditions1: dict,
+    conditions2: dict,
+    tolerance: float,
+) -> bool:
+    """
+    Check if two condition dictionaries match within tolerance.
+
+    Args:
+        conditions1: First conditions dictionary
+        conditions2: Second conditions dictionary
+        tolerance: Percentage tolerance for numerical comparison
+
+    Returns:
+        bool: True if conditions match within tolerance
+    """
+    # Must have same keys
+    if set(conditions1.keys()) != set(conditions2.keys()):
+        return False
+
+    # Check each value
+    for key in conditions1:
+        val1, val2 = conditions1[key], conditions2[key]
+
+        # Handle None values
+        if val1 is None or val2 is None:
+            if val1 != val2:
+                return False
+            continue
+
+        # Check tolerance
+        if isinstance(val1, (int, float)) and isinstance(val2, (int, float)):
+            if not _values_match_with_tolerance(val1, val2, tolerance):
+                return False
+
+    return True
+
+
+def _values_match_with_tolerance(
+    val1: float,
+    val2: float,
+    tolerance: float,
+) -> bool:
+    """
+    Check if two numerical values match within percentage tolerance.
+
+    Args:
+        val1: First value
+        val2: Second value
+        tolerance: Percentage tolerance (e.g., 0.05 for 5%)
+
+    Returns:
+        bool: True if values match within tolerance
+    """
+    if val1 == 0 and val2 == 0:
+        return True
+
+    if val1 == 0 or val2 == 0:
+        return abs(val1 - val2) <= tolerance
+
+    # Percentage difference
+    relative_diff = abs(val1 - val2) / max(abs(val1), abs(val2))
+    return relative_diff <= tolerance
 
 
 def _conditions_to_hashable(conditions: dict) -> tuple:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyenzyme"
-version = "2.0.1"
+version = "2.1.0"
 description = "A Python library for EnzymeML"
 authors = ["Jan Range <range.jan@web.de>"]
 license = "BSD 2-Clause License"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyenzyme"
-version = "2.0.0"
+version = "2.0.1"
 description = "A Python library for EnzymeML"
 authors = ["Jan Range <range.jan@web.de>"]
 license = "BSD 2-Clause License"

--- a/tests/integration/test_enzymeml.py
+++ b/tests/integration/test_enzymeml.py
@@ -1,9 +1,9 @@
 import os
 import tempfile
+
 import pyenzyme as pe
 import pyenzyme.equations as peq
-
-from pyenzyme.tools import get_all_parameters, to_dict_wo_json_ld
+from pyenzyme.tools import to_dict_wo_json_ld
 
 
 class TestEnzymeML:
@@ -71,7 +71,7 @@ class TestEnzymeML:
             time_unit="s",
         )
 
-        for parameter in get_all_parameters(doc):
+        for parameter in doc.parameters:
             parameter.lower_bound = 0.0
             parameter.upper_bound = 100.0
             parameter.stderr = 0.1

--- a/tests/integration/test_sbml.py
+++ b/tests/integration/test_sbml.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel
 
 import pyenzyme as pe
 import pyenzyme.equations as peq
-from pyenzyme.tools import to_dict_wo_json_ld, get_all_parameters
+from pyenzyme.tools import to_dict_wo_json_ld
 
 
 class TestSBML:
@@ -108,7 +108,7 @@ class TestSBML:
             time_unit="s",
         )
 
-        for parameter in get_all_parameters(doc):
+        for parameter in doc.parameters:
             parameter.lower_bound = 0.0
             parameter.upper_bound = 100.0
             parameter.stderr = 0.1

--- a/tests/unit/test_group_measurements.py
+++ b/tests/unit/test_group_measurements.py
@@ -1,0 +1,364 @@
+from unittest.mock import Mock
+
+from pyenzyme.tools import (
+    _conditions_to_hashable,
+    _get_measurement_conditions,
+    group_measurements,
+)
+
+
+class TestGetMeasurementConditions:
+    """Test suite for _get_measurement_conditions function"""
+
+    def test_with_prepared_values(self):
+        """Test extracting conditions from measurement with prepared values"""
+        # Arrange
+        species_data = [
+            Mock(species_id="s1", prepared=10.0, initial=None),
+            Mock(species_id="s2", prepared=5.0, initial=None),
+        ]
+        measurement = Mock(species_data=species_data, ph=7.4, temperature=25.0)
+
+        # Act
+        conditions = _get_measurement_conditions(measurement)
+
+        # Assert
+        expected = {"s1": 10.0, "s2": 5.0, "ph": 7.4, "temperature": 25.0}
+        assert conditions == expected
+
+    def test_with_initial_values(self):
+        """Test extracting conditions from measurement with initial values"""
+        # Arrange
+        species_data = [
+            Mock(species_id="s1", prepared=None, initial=8.0),
+            Mock(species_id="s2", prepared=None, initial=3.0),
+        ]
+        measurement = Mock(species_data=species_data, ph=6.8, temperature=30.0)
+
+        # Act
+        conditions = _get_measurement_conditions(measurement)
+
+        # Assert
+        expected = {"s1": 8.0, "s2": 3.0, "ph": 6.8, "temperature": 30.0}
+        assert conditions == expected
+
+    def test_prepared_takes_precedence_over_initial(self):
+        """Test that prepared values take precedence over initial values"""
+        # Arrange
+        species_data = [
+            Mock(species_id="s1", prepared=15.0, initial=10.0),
+            Mock(species_id="s2", prepared=None, initial=5.0),
+        ]
+        measurement = Mock(species_data=species_data, ph=None, temperature=None)
+
+        # Act
+        conditions = _get_measurement_conditions(measurement)
+
+        # Assert
+        expected = {
+            "s1": 15.0,  # prepared value used
+            "s2": 5.0,  # initial value used since prepared is None
+        }
+        assert conditions == expected
+
+    def test_with_no_concentration_values(self):
+        """Test with species data having no prepared or initial values"""
+        # Arrange
+        species_data = [
+            Mock(species_id="s1", prepared=None, initial=None),
+            Mock(species_id="s2", prepared=12.0, initial=None),
+        ]
+        measurement = Mock(species_data=species_data, ph=7.0, temperature=None)
+
+        # Act
+        conditions = _get_measurement_conditions(measurement)
+
+        # Assert
+        expected = {
+            "s2": 12.0,  # only s2 included since s1 has no values
+            "ph": 7.0,
+        }
+        assert conditions == expected
+
+    def test_with_no_environmental_conditions(self):
+        """Test with measurement having no pH or temperature"""
+        # Arrange
+        species_data = [
+            Mock(species_id="enzyme", prepared=1.0, initial=None),
+        ]
+        measurement = Mock(species_data=species_data, ph=None, temperature=None)
+
+        # Act
+        conditions = _get_measurement_conditions(measurement)
+
+        # Assert
+        expected = {
+            "enzyme": 1.0,
+        }
+        assert conditions == expected
+
+    def test_with_empty_species_data(self):
+        """Test with measurement having no species data"""
+        # Arrange
+        measurement = Mock(species_data=[], ph=7.5, temperature=37.0)
+
+        # Act
+        conditions = _get_measurement_conditions(measurement)
+
+        # Assert
+        expected = {"ph": 7.5, "temperature": 37.0}
+        assert conditions == expected
+
+
+class TestConditionsToHashable:
+    """Test suite for _conditions_to_hashable function"""
+
+    def test_with_normal_conditions(self):
+        """Test converting normal conditions dict to hashable tuple"""
+        # Arrange
+        conditions = {"s1": 10.0, "ph": 7.4, "temperature": 25.0, "s2": 5.0}
+
+        # Act
+        hashable = _conditions_to_hashable(conditions)
+
+        # Assert
+        expected = (("ph", 7.4), ("s1", 10.0), ("s2", 5.0), ("temperature", 25.0))
+        assert hashable == expected
+        assert isinstance(hashable, tuple)
+
+    def test_with_empty_conditions(self):
+        """Test converting empty conditions dict"""
+        # Arrange
+        conditions = {}
+
+        # Act
+        hashable = _conditions_to_hashable(conditions)
+
+        # Assert
+        assert hashable == ()
+        assert isinstance(hashable, tuple)
+
+    def test_order_consistency(self):
+        """Test that the same conditions always produce the same hashable tuple"""
+        # Arrange
+        conditions1 = {"b": 2, "a": 1, "c": 3}
+        conditions2 = {"c": 3, "a": 1, "b": 2}
+
+        # Act
+        hashable1 = _conditions_to_hashable(conditions1)
+        hashable2 = _conditions_to_hashable(conditions2)
+
+        # Assert
+        assert hashable1 == hashable2
+        assert hashable1 == (("a", 1), ("b", 2), ("c", 3))
+
+    def test_hashable_can_be_used_as_dict_key(self):
+        """Test that the returned tuple can be used as a dictionary key"""
+        # Arrange
+        conditions = {"s1": 10.0, "ph": 7.4}
+        hashable = _conditions_to_hashable(conditions)
+
+        # Act & Assert
+        test_dict = {hashable: "group_1"}
+        assert test_dict[hashable] == "group_1"
+
+
+class TestGroupMeasurements:
+    """Test suite for group_measurements function"""
+
+    def test_with_identical_conditions(self):
+        """Test grouping measurements with identical conditions"""
+        # Arrange
+        species_data1 = [Mock(species_id="s1", prepared=10.0, initial=None)]
+        species_data2 = [Mock(species_id="s1", prepared=10.0, initial=None)]
+
+        measurement1 = Mock(
+            species_data=species_data1, ph=7.4, temperature=25.0, group_id=None
+        )
+        measurement2 = Mock(
+            species_data=species_data2, ph=7.4, temperature=25.0, group_id=None
+        )
+
+        enzmldoc = Mock(measurements=[measurement1, measurement2])
+
+        # Act
+        result = group_measurements(enzmldoc)
+
+        # Assert
+        assert result == enzmldoc
+        assert measurement1.group_id == measurement2.group_id
+        assert measurement1.group_id == "group_0"
+
+    def test_with_different_conditions(self):
+        """Test grouping measurements with different conditions"""
+        # Arrange
+        species_data1 = [Mock(species_id="s1", prepared=10.0, initial=None)]
+        species_data2 = [
+            Mock(species_id="s1", prepared=15.0, initial=None)
+        ]  # Different concentration
+
+        measurement1 = Mock(
+            species_data=species_data1, ph=7.4, temperature=25.0, group_id=None
+        )
+        measurement2 = Mock(
+            species_data=species_data2, ph=7.4, temperature=25.0, group_id=None
+        )
+
+        enzmldoc = Mock(measurements=[measurement1, measurement2])
+
+        # Act
+        result = group_measurements(enzmldoc)
+
+        # Assert
+        assert result == enzmldoc
+        assert measurement1.group_id != measurement2.group_id
+        assert measurement1.group_id == "group_0"
+        assert measurement2.group_id == "group_1"
+
+    def test_with_different_ph(self):
+        """Test grouping measurements with different pH values"""
+        # Arrange
+        species_data1 = [Mock(species_id="s1", prepared=10.0, initial=None)]
+        species_data2 = [Mock(species_id="s1", prepared=10.0, initial=None)]
+
+        measurement1 = Mock(
+            species_data=species_data1, ph=7.4, temperature=25.0, group_id=None
+        )
+        measurement2 = Mock(
+            species_data=species_data2,
+            ph=8.0,  # Different pH
+            temperature=25.0,
+            group_id=None,
+        )
+
+        enzmldoc = Mock(measurements=[measurement1, measurement2])
+
+        # Act
+        group_measurements(enzmldoc)
+
+        # Assert
+        assert measurement1.group_id != measurement2.group_id
+        assert measurement1.group_id == "group_0"
+        assert measurement2.group_id == "group_1"
+
+    def test_with_no_measurements(self):
+        """Test with document containing no measurements"""
+        # Arrange
+        enzmldoc = Mock(measurements=[])
+
+        # Act
+        result = group_measurements(enzmldoc)
+
+        # Assert
+        assert result == enzmldoc
+
+    def test_with_single_measurement(self):
+        """Test with document containing single measurement"""
+        # Arrange
+        species_data = [Mock(species_id="s1", prepared=10.0, initial=None)]
+        measurement = Mock(
+            species_data=species_data, ph=7.4, temperature=25.0, group_id=None
+        )
+        enzmldoc = Mock(measurements=[measurement])
+
+        # Act
+        result = group_measurements(enzmldoc)
+
+        # Assert
+        assert result == enzmldoc
+        assert measurement.group_id == "group_0"
+
+    def test_with_multiple_identical_and_different_conditions(self):
+        """Test complex scenario with multiple measurements having various conditions"""
+        # Arrange
+        # Two measurements with identical conditions
+        species_data1 = [Mock(species_id="s1", prepared=10.0, initial=None)]
+        species_data2 = [Mock(species_id="s1", prepared=10.0, initial=None)]
+
+        # One measurement with different conditions
+        species_data3 = [Mock(species_id="s1", prepared=15.0, initial=None)]
+
+        # Another measurement identical to the first two
+        species_data4 = [Mock(species_id="s1", prepared=10.0, initial=None)]
+
+        measurement1 = Mock(
+            species_data=species_data1, ph=7.4, temperature=25.0, group_id=None
+        )
+        measurement2 = Mock(
+            species_data=species_data2, ph=7.4, temperature=25.0, group_id=None
+        )
+        measurement3 = Mock(
+            species_data=species_data3, ph=7.4, temperature=25.0, group_id=None
+        )
+        measurement4 = Mock(
+            species_data=species_data4, ph=7.4, temperature=25.0, group_id=None
+        )
+
+        enzmldoc = Mock(
+            measurements=[measurement1, measurement2, measurement3, measurement4]
+        )
+
+        # Act
+        group_measurements(enzmldoc)
+
+        # Assert
+        # measurement1, measurement2, and measurement4 should have the same group_id
+        assert measurement1.group_id == measurement2.group_id == measurement4.group_id
+        assert measurement3.group_id != measurement1.group_id
+        assert measurement1.group_id == "group_0"
+        assert measurement3.group_id == "group_1"
+
+    def test_group_id_format(self):
+        """Test that group IDs follow the expected format"""
+        # Arrange
+        species_data1 = [Mock(species_id="s1", prepared=10.0, initial=None)]
+        species_data2 = [Mock(species_id="s1", prepared=15.0, initial=None)]
+        species_data3 = [Mock(species_id="s1", prepared=20.0, initial=None)]
+        species_data4 = [Mock(species_id="s1", prepared=20.0, initial=None)]
+
+        measurement1 = Mock(
+            species_data=species_data1, ph=7.4, temperature=25.0, group_id=None
+        )
+        measurement2 = Mock(
+            species_data=species_data2, ph=7.4, temperature=25.0, group_id=None
+        )
+        measurement3 = Mock(
+            species_data=species_data3, ph=7.4, temperature=25.0, group_id=None
+        )
+        measurement4 = Mock(
+            species_data=species_data4, ph=7.4, temperature=25.0, group_id=None
+        )
+
+        enzmldoc = Mock(
+            measurements=[measurement1, measurement2, measurement3, measurement4]
+        )
+
+        # Act
+        group_measurements(enzmldoc)
+
+        # Assert
+        assert measurement1.group_id == "group_0"
+        assert measurement2.group_id == "group_1"
+        assert measurement3.group_id == "group_2"
+        assert measurement4.group_id == "group_2"
+
+
+class TestGroupMeasurementsIntegration:
+    """Integration tests using the existing fixtures"""
+
+    def test_with_valid_measurement_fixture(self, measurement_valid):
+        """Test group_measurements with the existing valid measurement fixture"""
+        # Arrange
+        original_measurements = measurement_valid.measurements.copy()
+
+        # Act
+        result = group_measurements(measurement_valid)
+
+        # Assert
+        assert result == measurement_valid
+        assert len(measurement_valid.measurements) == len(original_measurements)
+
+        # Check that all measurements got group_ids assigned
+        for measurement in measurement_valid.measurements:
+            assert measurement.group_id is not None
+            assert measurement.group_id.startswith("group_")


### PR DESCRIPTION
This PR introduces a convenience method `pe.group_measurements()` that assigns a group_id to all `Measurement` entries within an `EnzymeMLDocument`. The method compares all `MeasurementData` associated with each species and groups those sharing identical initial conditions under the same `group_id`.

Additionally, this PR refactors internal imports by replacing top-level import pyenzyme statements with explicit submodule imports. This change mitigates circular import issues, particularly when pyenzyme is used as a dependency in third-party packages.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/EnzymeML/PyEnzyme/80)
<!-- Reviewable:end -->
