### PR TITLE
Add `fit` flag for `Parameter`

### DIFF
--- a/pyenzyme/thinlayers/psyces.py
+++ b/pyenzyme/thinlayers/psyces.py
@@ -264,16 +264,18 @@ class ThinLayerPysces(BaseThinLayer):
             >>> pe.write_enzymeml(optimized_doc, "optimized_model.json")
         """
         nu_enzmldoc = self.enzmldoc.model_copy(deep=True)
-        results = self.minimizer.result.params.valuesdict()  # type: ignore
+        results = self.minimizer.result.params  # type: ignore
 
-        for name, value in results.items():
+        for name in results:
             query = nu_enzmldoc.filter_parameters(symbol=name)
 
             if len(query) == 0:
                 raise ValueError(f"Parameter {name} not found")
 
             parameter = query[0]
-            parameter.value = value
+            parameter.value = results[name].value
+            if results[name].stderr is not None:
+                parameter.stderr = results[name].stderr
 
         return nu_enzmldoc
 

--- a/pyenzyme/versions/v2.py
+++ b/pyenzyme/versions/v2.py
@@ -201,8 +201,8 @@ class EnzymeMLDocument(BaseModel):
         serialization_alias="@context",
         default_factory=lambda: {
             "enzml": "http://www.enzymeml.org/v2/",
-            "schema": "https://schema.org/",
             "OBO": "http://purl.obolibrary.org/obo/",
+            "schema": "https://schema.org/",
             "name": "schema:title",
             "created": "schema:dateCreated",
             "modified": "schema:dateModified",
@@ -603,6 +603,7 @@ class EnzymeMLDocument(BaseModel):
         initial_value: Optional[float] = None,
         upper_bound: Optional[float] = None,
         lower_bound: Optional[float] = None,
+        fit: Optional[bool] = True,
         stderr: Optional[float] = None,
         constant: Optional[bool] = True,
         **kwargs,
@@ -616,6 +617,7 @@ class EnzymeMLDocument(BaseModel):
             "initial_value": initial_value,
             "upper_bound": upper_bound,
             "lower_bound": lower_bound,
+            "fit": fit,
             "stderr": stderr,
             "constant": constant,
         }
@@ -659,8 +661,8 @@ class Creator(BaseModel):
         serialization_alias="@context",
         default_factory=lambda: {
             "enzml": "http://www.enzymeml.org/v2/",
-            "schema": "https://schema.org/",
             "OBO": "http://purl.obolibrary.org/obo/",
+            "schema": "https://schema.org/",
             "given_name": "schema:givenName",
             "family_name": "schema:familyName",
             "mail": "schema:email",
@@ -773,8 +775,8 @@ class Vessel(BaseModel):
         serialization_alias="@context",
         default_factory=lambda: {
             "enzml": "http://www.enzymeml.org/v2/",
-            "schema": "https://schema.org/",
             "OBO": "http://purl.obolibrary.org/obo/",
+            "schema": "https://schema.org/",
             "id": {
                 "@id": "schema:identifier",
                 "@type": "@id",
@@ -911,8 +913,8 @@ class Protein(BaseModel):
         serialization_alias="@context",
         default_factory=lambda: {
             "enzml": "http://www.enzymeml.org/v2/",
-            "schema": "https://schema.org/",
             "OBO": "http://purl.obolibrary.org/obo/",
+            "schema": "https://schema.org/",
             "id": {
                 "@id": "schema:identifier",
                 "@type": "@id",
@@ -1044,8 +1046,8 @@ class Complex(BaseModel):
         serialization_alias="@context",
         default_factory=lambda: {
             "enzml": "http://www.enzymeml.org/v2/",
-            "schema": "https://schema.org/",
             "OBO": "http://purl.obolibrary.org/obo/",
+            "schema": "https://schema.org/",
             "id": {
                 "@id": "schema:identifier",
                 "@type": "@id",
@@ -1195,8 +1197,8 @@ class SmallMolecule(BaseModel):
         serialization_alias="@context",
         default_factory=lambda: {
             "enzml": "http://www.enzymeml.org/v2/",
-            "schema": "https://schema.org/",
             "OBO": "http://purl.obolibrary.org/obo/",
+            "schema": "https://schema.org/",
             "id": {
                 "@id": "schema:identifier",
                 "@type": "@id",
@@ -1330,8 +1332,8 @@ class Reaction(BaseModel):
         serialization_alias="@context",
         default_factory=lambda: {
             "enzml": "http://www.enzymeml.org/v2/",
-            "schema": "https://schema.org/",
             "OBO": "http://purl.obolibrary.org/obo/",
+            "schema": "https://schema.org/",
             "id": {
                 "@id": "schema:identifier",
                 "@type": "@id",
@@ -1517,8 +1519,8 @@ class ReactionElement(BaseModel):
         serialization_alias="@context",
         default_factory=lambda: {
             "enzml": "http://www.enzymeml.org/v2/",
-            "schema": "https://schema.org/",
             "OBO": "http://purl.obolibrary.org/obo/",
+            "schema": "https://schema.org/",
             "species_id": {
                 "@id": "schema:identifier",
                 "@type": "@id",
@@ -1622,8 +1624,8 @@ class ModifierElement(BaseModel):
         serialization_alias="@context",
         default_factory=lambda: {
             "enzml": "http://www.enzymeml.org/v2/",
-            "schema": "https://schema.org/",
             "OBO": "http://purl.obolibrary.org/obo/",
+            "schema": "https://schema.org/",
             "species_id": {
                 "@id": "schema:identifier",
                 "@type": "@id",
@@ -1738,8 +1740,8 @@ class Equation(BaseModel):
         serialization_alias="@context",
         default_factory=lambda: {
             "enzml": "http://www.enzymeml.org/v2/",
-            "schema": "https://schema.org/",
             "OBO": "http://purl.obolibrary.org/obo/",
+            "schema": "https://schema.org/",
             "species_id": {
                 "@id": "schema:identifier",
                 "@type": "@id",
@@ -1874,8 +1876,8 @@ class Variable(BaseModel):
         serialization_alias="@context",
         default_factory=lambda: {
             "enzml": "http://www.enzymeml.org/v2/",
-            "schema": "https://schema.org/",
             "OBO": "http://purl.obolibrary.org/obo/",
+            "schema": "https://schema.org/",
             "id": {
                 "@id": "schema:identifier",
                 "@type": "@id",
@@ -1989,6 +1991,11 @@ class Parameter(BaseModel):
         description="""Lower bound for the parameter value that was used
         for the parameter estimation""",
     )
+    fit: Optional[bool] = Field(
+        default=True,
+        description="""Whether this parameter should be varied or not in
+        the context of an optimization.""",
+    )
     stderr: Optional[float] = Field(
         default=None,
         description="""Standard error of the estimated parameter.""",
@@ -2014,8 +2021,8 @@ class Parameter(BaseModel):
         serialization_alias="@context",
         default_factory=lambda: {
             "enzml": "http://www.enzymeml.org/v2/",
-            "schema": "https://schema.org/",
             "OBO": "http://purl.obolibrary.org/obo/",
+            "schema": "https://schema.org/",
             "id": {
                 "@id": "schema:identifier",
                 "@type": "@id",
@@ -2141,8 +2148,8 @@ class Measurement(BaseModel):
         serialization_alias="@context",
         default_factory=lambda: {
             "enzml": "http://www.enzymeml.org/v2/",
-            "schema": "https://schema.org/",
             "OBO": "http://purl.obolibrary.org/obo/",
+            "schema": "https://schema.org/",
             "id": {
                 "@id": "schema:identifier",
                 "@type": "@id",
@@ -2330,8 +2337,8 @@ class MeasurementData(BaseModel):
         serialization_alias="@context",
         default_factory=lambda: {
             "enzml": "http://www.enzymeml.org/v2/",
-            "schema": "https://schema.org/",
             "OBO": "http://purl.obolibrary.org/obo/",
+            "schema": "https://schema.org/",
             "species_id": {
                 "@type": "@id",
             },


### PR DESCRIPTION
This pull request makes improvements to the `pyenzyme/versions/v2.py` data model, primarily by the addition of a `fit` attribute to parameters and the consistent placement of the `"schema": "https://schema.org/"` entry in context definitions. This

**Parameter handling improvements:**

* Added an optional `fit` attribute to the `Parameter` model to indicate whether the parameter should be varied during optimization. This is now included both in the model definition and when adding parameters via `add_to_parameters`. [[1]](diffhunk://#diff-454e6f00be832f8843c4fe5d4424f6f55e658525455e0406c66183a0b53f9338R1994-R1998) [[2]](diffhunk://#diff-454e6f00be832f8843c4fe5d4424f6f55e658525455e0406c66183a0b53f9338R606) [[3]](diffhunk://#diff-454e6f00be832f8843c4fe5d4424f6f55e658525455e0406c66183a0b53f9338R620)

**Submodule update:**

* Updated the `specs` submodule to the current main branch of [EnzymeML specs](https://github.com/EnzymeML/enzymeml-specifications/commit/c5dc877bdbc4d99ce1b57009583cfe3dc97163fb), reflecting the latest changes in the external dependency.

**Related PRs**

Since this is a general change to the EnzymeML data model, other libraries have been synced as well. Once this PR is merged, all others will be merged as well:

- https://github.com/EnzymeML/enzymeml-ts/pull/5
- https://github.com/EnzymeML/enzymeml-go/pull/1
- https://github.com/EnzymeML/enzymeml-rs/pull/10
- https://github.com/EnzymeML/EnzymeML.jl/pull/1

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/EnzymeML/PyEnzyme/85)
<!-- Reviewable:end -->
