### PR TITLE
Fix PySCeS and Copasi thinlayer imports

### DIFF
--- a/pyenzyme/thinlayers/__init__.py
+++ b/pyenzyme/thinlayers/__init__.py
@@ -1,36 +1,25 @@
 from .base import BaseThinLayer
 
-# Only import and show warnings if the modules are explicitly requested
-ThinLayerPysces = None
-ThinLayerCopasi = None
-
-
 def _get_pysces():
     global ThinLayerPysces
-    if ThinLayerPysces is None:
-        try:
-            from .psyces import ThinLayerPysces as _ThinLayerPysces
-
-            ThinLayerPysces = _ThinLayerPysces
-        except ImportError as e:
-            raise ImportError(
-                f"ThinLayerPysces is not available because of missing dependencies: {e}"
-            )
-    return ThinLayerPysces
+    try:
+        from .psyces import ThinLayerPysces as _ThinLayerPysces
+    except ImportError as e:
+        raise ImportError(
+            f"ThinLayerPysces is not available because of missing dependencies: {e}"
+        )
+    return _ThinLayerPysces
 
 
 def _get_copasi():
     global ThinLayerCopasi
-    if ThinLayerCopasi is None:
-        try:
-            from .basico import ThinLayerCopasi as _ThinLayerCopasi
-
-            ThinLayerCopasi = _ThinLayerCopasi
-        except ImportError as e:
-            raise ImportError(
-                f"ThinLayerCopasi is not available because of missing dependencies: {e}"
-            )
-    return ThinLayerCopasi
+    try:
+        from .basico import ThinLayerCopasi as _ThinLayerCopasi
+    except ImportError as e:
+        raise ImportError(
+            f"ThinLayerCopasi is not available because of missing dependencies: {e}"
+        )
+    return _ThinLayerCopasi
 
 
 def __getattr__(name):


### PR DESCRIPTION
By defining
```python
ThinLayerPysces = None
ThinLayerCopasi = None
```
these names exist in the namespace already, and as a consequence the `__getattr__(name)` method never gets called. As a consequence the thinlayers are imported as `None` objects and not the actual thinlayers.

This PR fixes this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/EnzymeML/PyEnzyme/93)
<!-- Reviewable:end -->
